### PR TITLE
feat(cache): implement multi-level cache service with prefix tree

### DIFF
--- a/.kiro/specs/cache-service/.config.kiro
+++ b/.kiro/specs/cache-service/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "a001a2a5-73b0-4189-b531-f7653ecf2725", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/cache-service/design.md
+++ b/.kiro/specs/cache-service/design.md
@@ -1,0 +1,366 @@
+# 技术设计文档：cache-service
+
+## 概述
+
+mcache 是一个支持多级 key 路径的内存键值缓存服务。系统以 `/` 分隔的路径字符串（Prefix）作为唯一标识，通过前缀树（PrefixTree）维护层级关系，底层使用 `sync.Map` 保证并发安全。
+
+系统支持两种集成模式：
+- **HTTP 服务模式**：作为独立进程运行，通过 REST API 对外提供服务
+- **Module 嵌入模式**：以 Go module 形式直接嵌入宿主程序，共享同一套存储实现
+
+当前技术栈：Go 1.21、Gin v1.9、logrus v1.9。
+
+---
+
+## 架构
+
+```mermaid
+graph TD
+    A[HTTP Client] -->|REST API| B[Gin HTTP Server]
+    C[Go Module Client] -->|Direct Call| D[Handler Layer]
+    B --> D
+    D --> E[PrefixTree Handler]
+    D --> F[Storage Client]
+    E --> F
+    F --> G[Memory Storage\nsync.Map]
+```
+
+### 分层说明
+
+| 层次 | 包路径 | 职责 |
+|------|--------|------|
+| API 类型层 | `pkg/apis/v1/` | 定义 Item、Storage 接口、PrefixTree 类型 |
+| HTTP 路由层 | `pkg/services/rest/` | Gin 路由注册、请求解析、响应格式化 |
+| 业务逻辑层 | `pkg/handlers/` | PrefixTree 操作、TTL 检查、数据协调 |
+| 存储层 | `pkg/storage/` | Storage 接口代理，当前实现为内存存储 |
+| 内存存储 | `pkg/storage/memory/` | sync.Map + prefixList 实现 |
+
+---
+
+## 组件与接口
+
+### Storage 接口（`pkg/apis/v1/storage/types.go`）
+
+```go
+type Storage interface {
+    GetOne(prefix string) (*item.Item, error)
+    ListPrefixData(prefix []string) ([]*item.Item, error)
+    CountPrefixData(prefixList []string) int
+    ListPrefix(prePrefix string) ([]string, error)
+    CountPrefix(prePrefix string) int
+    Insert(prefix string, data interface{}, opt ...item.Option) error
+    Update(prefix string, data []byte, opt ...item.Option) error
+    Delete(prefix string) (interface{}, error)
+}
+```
+
+**待新增方法**（支持需求 3、5）：
+- `Update` 方法需支持 `item.Option` 以传入新 TTL
+- `GetOne` 需在返回前检查 `expireTime`，过期则删除并返回 `NoDataError`
+
+### PrefixTree 接口（`pkg/apis/v1/prefix-tree/types.go`）
+
+当前接口仅有 `InsertNode`，需扩展为完整 CRUD：
+
+```go
+type PrefixTree interface {
+    InsertNode(prefix string, data interface{}) error
+    RemoveNode(prefix string) error
+    ListNode(prefix string) ([]*item.Item, error)
+    SearchNode(prefix string) (*PrefixNode, error)
+}
+```
+
+### HTTP 路由（`pkg/services/rest/`）
+
+| 方法 | 路径 | 处理函数 | 说明 |
+|------|------|----------|------|
+| PUT | `/v1/data` | `DataHandler.create` | 创建缓存条目 |
+| GET | `/v1/data/:prefix` | `DataHandler.get` | 读取单条 |
+| POST | `/v1/data/:prefix` | `DataHandler.update` | 更新条目（待实现） |
+| DELETE | `/v1/data/:prefix` | `DataHandler.delete` | 删除条目 |
+| GET | `/v1/data/listByPrefix` | `DataHandler.listByPrefix` | 前缀查询 |
+| GET | `/v1/prefix` | `PrefixHandler.list` | 列举所有前缀 |
+| GET | `/v1/prefix/count` | `PrefixHandler.count` | 统计前缀数量 |
+| GET | `/healthz` | 内联 | 健康检查 |
+
+### Module 客户端接口
+
+```go
+// pkg/client/cache.go（待新增）
+type CacheClient interface {
+    Insert(prefix string, data interface{}, opts ...item.Option) error
+    Get(prefix string) (*item.Item, error)
+    Update(prefix string, data []byte, opts ...item.Option) error
+    Delete(prefix string) error
+    ListByPrefix(prefix string) ([]*item.Item, error)
+}
+```
+
+---
+
+## 数据模型
+
+### Item（`pkg/apis/v1/item/types.go`）
+
+```go
+type Item struct {
+    Prefix     string        `json:"prefix"`
+    Data       interface{}   `json:"data"`
+    Timeout    time.Duration `json:"timeout,omitempty"`
+    ExpireTime time.Time     `json:"expireTime,omitempty"`
+    CreatedAt  time.Time     `json:"createdAt"`
+    UpdatedAt  time.Time     `json:"UpdatedAt"`
+}
+```
+
+- `Timeout` 为 0 表示永不过期
+- `ExpireTime` = `CreatedAt` + `Timeout`（仅在设置 TTL 时有效）
+- `Data` 为 `interface{}`，支持任意 JSON 可序列化类型
+
+### PrefixNode（`pkg/apis/v1/prefix-tree/types.go`）
+
+```go
+type PrefixNode struct {
+    Prefix    Prefix        `json:"prefix"`
+    HasData   bool          `json:"hasData"`
+    SubPrefix []*PrefixNode `json:"subPrefix"`
+    Timeout   time.Time     `json:"timeout"`
+}
+```
+
+- `HasData = true` 表示该节点对应的完整路径在 Storage 中有数据
+- 中间节点 `HasData` 可为 `false`，仅作路径索引
+- 删除末端节点后，中间节点保留，`HasData` 置为 `false`
+
+### PrefixGroup（路径解析结构）
+
+```
+输入: "/user/profile/name"
+解析:
+  RootPrefix: "user"
+  PrefixPath: ["profile"]
+  NodePrefix: "name"
+```
+
+- 前导 `/` 自动去除
+- 单段路径：`RootPrefix = NodePrefix`，`PrefixPath = []`
+
+### 错误类型（`pkg/apis/v1/item/errors.go`）
+
+| 错误变量 | 含义 |
+|----------|------|
+| `NoDataError` | 数据不存在或已过期 |
+| `PrefixExisted` | Prefix 已存在，拒绝重复插入 |
+| `PrefixNotExisted` | Prefix 不存在，删除/更新失败 |
+
+---
+
+## TTL 过期机制设计
+
+TTL 通过 `item.Option` 函数选项模式注入：
+
+```go
+func WithTTL(d time.Duration) item.Option {
+    return func(i *item.Item) {
+        i.Timeout = d
+        i.ExpireTime = time.Now().Add(d)
+    }
+}
+```
+
+过期检查在 `GetOne` 中执行（惰性删除）：
+
+```go
+func (m *Memory) GetOne(prefix string) (*item.Item, error) {
+    data, has := m.dataMap.Load(prefix)
+    if !has {
+        return nil, item.NoDataError
+    }
+    it := data.(*item.Item)
+    if !it.ExpireTime.IsZero() && it.ExpireTime.Before(time.Now()) {
+        m.Delete(prefix)
+        return nil, item.NoDataError
+    }
+    return it, nil
+}
+```
+
+**设计决策**：采用惰性删除而非定时扫描，避免后台 goroutine 带来的复杂性，适合当前内存存储规模。
+
+---
+
+## 并发安全设计
+
+- `sync.Map` 保证 `dataMap` 的并发读写安全
+- `prefixList` 为普通切片，存在并发写入竞争风险
+
+**待修复**：`prefixList` 的并发写入需加锁保护，或改用 `sync.Map` 存储前缀集合：
+
+```go
+type Memory struct {
+    mu         sync.RWMutex
+    prefixList []string
+    dataMap    *sync.Map
+}
+```
+
+插入/删除 `prefixList` 时持有 `mu` 写锁，`CountPrefix`/`ListPrefix` 持有读锁。
+
+---
+
+## 正确性属性
+
+*属性（Property）是在系统所有合法执行中都应成立的特征或行为，是人类可读规范与机器可验证正确性保证之间的桥梁。*
+
+### 属性 1：插入-查询往返一致性
+
+*对于任意* 合法 Prefix 和 JSON 可序列化的 Data，将其插入后立即查询，应返回与插入时相同的 Data 内容。
+
+**验证需求：1.1、1.4、4.1**
+
+### 属性 2：重复插入拒绝
+
+*对于任意* Prefix，连续插入两次，第二次插入应返回 `PrefixExisted` 错误，且 Storage 中的数据保持第一次插入的值不变。
+
+**验证需求：1.2**
+
+### 属性 3：插入时间戳正确性
+
+*对于任意* 插入操作，插入成功后查询到的 Item，其 `createdAt` 和 `updatedAt` 应在插入操作发生的时间范围内（不早于操作开始时间，不晚于操作结束时间）。
+
+**验证需求：1.3**
+
+### 属性 4：Prefix 解析往返一致性
+
+*对于任意* 合法的多级 Prefix 字符串（含或不含前导 `/`），解析为 PrefixGroup 后重新拼接，应产生与去除前导 `/` 后的原始字符串等价的结果。
+
+**验证需求：2.5、10.1、10.2、10.3、10.4**
+
+### 属性 5：前缀查询完整性
+
+*对于任意* 父路径前缀，在其下插入若干直接子节点后，按该父路径前缀查询，返回列表应恰好包含所有已插入的直接子节点 Item，不多不少。
+
+**验证需求：2.4、4.3**
+
+### 属性 6：TTL 过期行为
+
+*对于任意* 设置了 TTL 的 Item，在 `expireTime` 之后查询，应返回 `NoDataError`；在 `expireTime` 之前查询，应返回正确数据。未设置 TTL 的 Item 永远不应因过期而返回 `NoDataError`。
+
+**验证需求：3.1、3.2、3.3**
+
+### 属性 7：更新保留原有 TTL
+
+*对于任意* 带有 `expireTime` 的 Item，在不提供新 TTL 的情况下更新其 Data，更新后查询到的 `expireTime` 应与更新前完全相同。
+
+**验证需求：3.4、5.3**
+
+### 属性 8：更新后数据一致性
+
+*对于任意* 已存在的 Prefix，更新其 Data 后立即查询，应返回新的 Data 值，且 `updatedAt` 时间戳应晚于原始 `updatedAt`。
+
+**验证需求：5.1**
+
+### 属性 9：删除后不可查询
+
+*对于任意* 已存在的 Prefix，删除后立即查询，应返回 `NoDataError`；对应 PrefixTree 节点的 `HasData` 应为 `false`，但节点本身仍存在于树中。
+
+**验证需求：6.1、6.3**
+
+### 属性 10：并发写入安全性
+
+*对于任意* Prefix，当 N 个 goroutine 并发执行插入操作时，恰好有且仅有一次插入成功，其余均返回 `PrefixExisted` 错误，且最终 Storage 中该 Prefix 对应的数据完整无损。
+
+**验证需求：9.1、9.3**
+
+### 属性 11：空路径前缀查询返回空列表
+
+*对于任意* 不存在子节点的路径前缀，查询应返回空列表而非错误。
+
+**验证需求：4.4**
+
+---
+
+## 错误处理
+
+### 业务错误到 HTTP 状态码映射
+
+| 业务错误 | HTTP 状态码 | 场景 |
+|----------|-------------|------|
+| `NoDataError` | 404 | 查询/删除不存在的数据 |
+| `PrefixExisted` | 409 | 重复插入 |
+| `PrefixNotExisted` | 404 | 删除不存在的 Prefix |
+| JSON 解析失败 | 400 | 请求体格式非法 |
+| 其他内部错误 | 500 | 未预期的系统错误 |
+
+### 错误响应格式
+
+```json
+{
+  "code": 404,
+  "message": "cache not found",
+  "timestamp": 1700000000
+}
+```
+
+**设计决策**：500 错误仅返回错误描述字符串，不暴露 goroutine 堆栈，由 Gin 的 `Recovery()` 中间件兜底处理 panic。
+
+### 边界条件处理
+
+- 空 Prefix：在 Handler 层校验，返回 400
+- 前导 `/` 的 Prefix：在 `SplitPrefix()` 中自动去除
+- 并发删除同一 Prefix：`sync.Map.Delete` 是幂等的，`prefixList` 删除需加锁
+
+---
+
+## 测试策略
+
+### 双轨测试方法
+
+采用单元测试 + 属性测试互补的方式：
+- **单元测试**：验证具体示例、边界条件、错误路径
+- **属性测试**：验证对所有输入都成立的通用属性
+
+### 属性测试配置
+
+使用 [gopter](https://github.com/leanovate/gopter) 作为 Go 属性测试库。
+
+每个属性测试最少运行 **100 次**迭代。每个测试用注释标注对应的设计属性：
+
+```go
+// Feature: cache-service, Property 1: 插入-查询往返一致性
+func TestInsertGetRoundTrip(t *testing.T) {
+    properties := gopter.NewProperties(gopter.DefaultTestParameters())
+    properties.Property("insert then get returns same data", prop.ForAll(
+        func(prefix string, data string) bool {
+            // ...
+        },
+        gen.AlphaString().SuchThat(func(s string) bool { return len(s) > 0 }),
+        gen.AlphaString(),
+    ))
+    properties.TestingRun(t)
+}
+```
+
+### 单元测试覆盖点
+
+- HTTP 接口：各端点的正常响应、400/404/500 错误码
+- `SplitPrefix`：各种路径格式（单段、多段、前导 `/`、空字符串）
+- TTL 选项：`WithTTL` 函数的正确计算
+- Module 客户端：接口方法的基本调用
+
+### 属性测试覆盖点（对应设计属性）
+
+| 属性编号 | 测试文件 | 生成器策略 |
+|----------|----------|------------|
+| 属性 1 | `storage/memory/memory_test.go` | 随机 Prefix + 随机 JSON 数据 |
+| 属性 2 | `storage/memory/memory_test.go` | 随机 Prefix，插入两次 |
+| 属性 3 | `storage/memory/memory_test.go` | 随机 Item，检查时间戳范围 |
+| 属性 4 | `apis/v1/prefix-tree/types_test.go` | 随机多级路径字符串 |
+| 属性 5 | `handlers/data_test.go` | 随机父路径 + 随机子节点集合 |
+| 属性 6 | `storage/memory/memory_test.go` | 随机 TTL（正值/负值/零） |
+| 属性 7 | `storage/memory/memory_test.go` | 随机 Item + 随机更新数据 |
+| 属性 8 | `storage/memory/memory_test.go` | 随机 Prefix + 两个不同 Data |
+| 属性 9 | `handlers/data_test.go` | 随机 Prefix，插入后删除 |
+| 属性 10 | `storage/memory/memory_test.go` | 固定 Prefix，N goroutine 并发插入 |
+| 属性 11 | `handlers/data_test.go` | 随机不存在子节点的路径 |

--- a/.kiro/specs/cache-service/requirements.md
+++ b/.kiro/specs/cache-service/requirements.md
@@ -1,0 +1,155 @@
+# 需求文档
+
+## 简介
+
+本文档描述 mcache 缓存服务的功能需求。mcache 是一个支持多级 key 路径的键值缓存服务，数据存储于 key 路径的末端节点。系统支持两种集成方式：作为 Go module 直接嵌入宿主程序内存，或作为独立 HTTP 服务对外提供 REST 接口。
+
+## 词汇表
+
+- **Cache_Service**：缓存服务整体，负责数据的存储、检索、更新与删除。
+- **Storage**：底层存储引擎，当前实现为内存存储（Memory Storage）。
+- **Prefix**：由 `/` 分隔的多级 key 路径，例如 `/user/profile/name`，数据存储于路径末端节点。
+- **Item**：缓存条目，包含 Prefix、Data、过期时间、创建时间、更新时间等字段。
+- **PrefixTree**：前缀树，用于管理多级 key 路径的层级关系。
+- **TTL**：Time To Live，缓存条目的存活时长，超时后条目失效。
+- **HTTP_Server**：对外提供 REST API 的 HTTP 服务，基于 Gin 框架实现。
+- **Module_Client**：以 Go module 形式嵌入宿主程序的客户端接口。
+- **REST_API**：通过 HTTP 协议对外暴露的增删读改接口。
+
+---
+
+## 需求
+
+### 需求 1：键值数据存储
+
+**用户故事：** 作为开发者，我希望以键值对形式存储任意数据，以便在后续请求中快速检索。
+
+#### 验收标准
+
+1. THE Cache_Service SHALL 以 Prefix 作为唯一标识存储 Item。
+2. WHEN 插入请求携带相同 Prefix 时，THE Cache_Service SHALL 返回 `prefix already existed` 错误，拒绝重复插入。
+3. WHEN 插入成功时，THE Storage SHALL 记录 Item 的 `createdAt` 与 `updatedAt` 时间戳为当前时间。
+4. THE Cache_Service SHALL 支持存储任意 JSON 可序列化的数据类型作为 Item 的 Data 字段。
+
+---
+
+### 需求 2：多级 key 路径
+
+**用户故事：** 作为开发者，我希望使用 `/` 分隔的多级路径作为 key，以便对数据进行层级化组织与管理。
+
+#### 验收标准
+
+1. THE Cache_Service SHALL 将 Prefix 按 `/` 分隔解析为多级路径，并在 PrefixTree 中维护层级关系。
+2. WHEN Prefix 为空或格式非法时，THE Cache_Service SHALL 返回描述性错误信息，拒绝操作。
+3. THE Cache_Service SHALL 仅在路径末端节点存储实际数据，中间节点仅作路径索引。
+4. WHEN 查询某一路径前缀时，THE Cache_Service SHALL 返回该路径下所有直接子节点的 Item 列表。
+5. FOR ALL 合法的多级 Prefix，THE PrefixTree SHALL 保证路径解析后再重新拼接与原始 Prefix 等价（往返一致性）。
+
+---
+
+### 需求 3：TTL 过期机制
+
+**用户故事：** 作为开发者，我希望为缓存条目设置失效时间，以便数据在指定时间后自动失效，避免脏数据长期占用内存。
+
+#### 验收标准
+
+1. WHERE TTL 选项被设置，THE Cache_Service SHALL 在 Item 中记录 `expireTime` 为当前时间加上 TTL 时长。
+2. WHEN 读取 Item 时，IF Item 的 `expireTime` 早于当前时间，THEN THE Cache_Service SHALL 返回 `no data` 错误，并将该 Item 从 Storage 中删除。
+3. WHERE TTL 选项未设置，THE Cache_Service SHALL 将 Item 视为永不过期。
+4. WHEN 更新 Item 时，WHERE 新的 TTL 选项被提供，THE Cache_Service SHALL 以新的 TTL 重新计算并覆盖 `expireTime`。
+
+---
+
+### 需求 4：数据读取
+
+**用户故事：** 作为开发者，我希望通过精确 Prefix 或路径前缀查询缓存数据，以便灵活检索单条或批量数据。
+
+#### 验收标准
+
+1. WHEN 以精确 Prefix 查询时，THE Cache_Service SHALL 返回对应的单条 Item。
+2. WHEN 以精确 Prefix 查询但数据不存在时，THE Cache_Service SHALL 返回 `no data` 错误。
+3. WHEN 以路径前缀查询时，THE Cache_Service SHALL 返回该前缀路径下所有直接子节点的 Item 列表。
+4. WHEN 路径前缀下无任何子节点数据时，THE Cache_Service SHALL 返回空列表而非错误。
+
+---
+
+### 需求 5：数据更新
+
+**用户故事：** 作为开发者，我希望更新已存在的缓存条目的数据内容，以便修正或刷新缓存值。
+
+#### 验收标准
+
+1. WHEN 更新请求携带已存在的 Prefix 时，THE Cache_Service SHALL 将该 Item 的 Data 替换为新值，并更新 `updatedAt` 时间戳。
+2. WHEN 更新请求携带不存在的 Prefix 时，THE Cache_Service SHALL 返回 `no data` 错误，拒绝更新。
+3. WHERE 更新请求未携带新的 TTL 选项，THE Cache_Service SHALL 保留 Item 原有的 `expireTime` 不变。
+
+---
+
+### 需求 6：数据删除
+
+**用户故事：** 作为开发者，我希望删除指定 Prefix 的缓存条目，以便主动清理不再需要的数据。
+
+#### 验收标准
+
+1. WHEN 删除请求携带已存在的 Prefix 时，THE Cache_Service SHALL 从 Storage 中移除该 Item，并在 PrefixTree 中将对应节点标记为无数据。
+2. WHEN 删除请求携带不存在的 Prefix 时，THE Cache_Service SHALL 返回 `prefix not existed` 错误。
+3. WHEN 删除末端节点后，IF 父路径节点下不再有任何含数据的子节点，THEN THE PrefixTree SHALL 保留路径结构，不自动删除中间节点。
+
+---
+
+### 需求 7：HTTP 服务模式
+
+**用户故事：** 作为运维人员，我希望将缓存服务作为独立进程部署，并通过 HTTP REST 接口进行数据操作，以便与任意语言的客户端集成。
+
+#### 验收标准
+
+1. THE HTTP_Server SHALL 在 `0.0.0.0:8080` 监听并提供以下 REST 接口：
+   - `PUT /v1/data` — 创建缓存条目
+   - `GET /v1/data/:prefix` — 读取单条缓存条目
+   - `POST /v1/data/:prefix` — 更新缓存条目
+   - `DELETE /v1/data/:prefix` — 删除缓存条目
+   - `GET /v1/data/listByPrefix?prefix=<path>` — 按路径前缀列举子节点
+2. WHEN HTTP 请求体格式非法时，THE HTTP_Server SHALL 返回 HTTP 400 状态码及描述性错误信息。
+3. WHEN 请求的资源不存在时，THE HTTP_Server SHALL 返回 HTTP 404 状态码。
+4. WHEN 服务内部发生错误时，THE HTTP_Server SHALL 返回 HTTP 500 状态码及错误描述，且不暴露内部堆栈信息。
+5. THE HTTP_Server SHALL 提供 `GET /healthz` 健康检查接口，正常时返回 HTTP 200。
+6. WHEN HTTP_Server 启动失败时，THE HTTP_Server SHALL 记录错误日志并终止进程。
+
+---
+
+### 需求 8：Module 嵌入模式
+
+**用户故事：** 作为 Go 开发者，我希望将缓存服务以 Go module 形式直接嵌入到我的程序中，以便在不启动独立服务的情况下使用缓存能力。
+
+#### 验收标准
+
+1. THE Module_Client SHALL 暴露与 HTTP 服务等价的增删读改及前缀查询接口，供宿主程序直接调用。
+2. THE Module_Client SHALL 与 HTTP_Server 共享同一套 Storage 与 PrefixTree 实现，保证行为一致性。
+3. WHERE Module_Client 被使用，THE Cache_Service SHALL 不启动任何 HTTP 监听端口。
+4. THE Module_Client SHALL 支持通过函数选项（Option 模式）配置 TTL 等参数。
+
+---
+
+### 需求 9：内存存储引擎
+
+**用户故事：** 作为开发者，我希望缓存数据默认存储于进程内存，以便获得最低延迟的读写性能。
+
+#### 验收标准
+
+1. THE Storage SHALL 使用 `sync.Map` 保证并发读写安全。
+2. THE Storage SHALL 维护 prefixList 以支持按前缀快速枚举 key。
+3. WHEN 并发写入相同 Prefix 时，THE Storage SHALL 保证只有一次写入成功，其余返回 `prefix already existed` 错误。
+4. THE Storage SHALL 实现 `storage.Storage` 接口，以便未来替换为其他存储后端（如 Redis）而无需修改上层逻辑。
+
+---
+
+### 需求 10：Prefix 序列化与反序列化
+
+**用户故事：** 作为开发者，我希望 Prefix 路径能够在字符串与结构化对象之间可靠转换，以便系统内部正确处理多级路径。
+
+#### 验收标准
+
+1. WHEN 解析 Prefix 字符串时，THE Cache_Service SHALL 将其拆分为 RootPrefix、中间路径段和 NodePrefix 组成的 PrefixGroup 结构。
+2. THE Cache_Service SHALL 提供将 PrefixGroup 重新拼接为完整 Prefix 字符串的能力。
+3. FOR ALL 合法的 Prefix 字符串，解析后再拼接 SHALL 产生与原始字符串等价的结果（往返一致性）。
+4. WHEN Prefix 字符串以 `/` 开头时，THE Cache_Service SHALL 自动去除前导 `/` 后再进行解析，结果与不含前导 `/` 的等价路径一致。

--- a/.kiro/specs/cache-service/tasks.md
+++ b/.kiro/specs/cache-service/tasks.md
@@ -1,0 +1,131 @@
+# 实现计划：cache-service
+
+## 概述
+
+基于需求文档与技术设计文档，将 mcache 缓存服务的缺失功能逐步实现并集成。主要工作包括：修复内存存储并发安全问题、补全 TTL 过期机制、实现数据更新接口、完善 HTTP 路由错误映射、新增 Module 嵌入客户端，以及为各核心属性编写属性测试。
+
+## 任务
+
+- [x] 1. 修复内存存储层并发安全问题
+  - 在 `pkg/storage/memory/memory.go` 的 `Memory` 结构体中添加 `sync.RWMutex` 字段
+  - 对 `prefixList` 的所有读操作（`ListPrefix`、`CountPrefix`）加读锁，写操作（`Insert`、`Delete`）加写锁
+  - 修复 `Insert` 中 `dataMap.Load` 与 `dataMap.Store` 之间的竞态：改用 `sync.Map.LoadOrStore` 保证原子性
+  - _需求：9.1、9.3_
+
+  - [ ]* 1.1 为并发写入安全性编写属性测试
+    - **属性 10：并发写入安全性**
+    - **验证：需求 9.1、9.3**
+    - 在 `pkg/storage/memory/memory_test.go` 中，用 N 个 goroutine 并发插入同一 Prefix，断言恰好一次成功
+
+- [x] 2. 实现 TTL 过期机制
+  - 在 `pkg/apis/v1/item/types.go` 中新增 `WithTTL(d time.Duration) item.Option` 函数
+  - 修改 `pkg/storage/memory/memory.go` 的 `GetOne`：若 `ExpireTime` 非零且早于当前时间，则调用 `Delete` 并返回 `NoDataError`
+  - 修改 `Insert`：应用 `opt` 后若 `Timeout > 0` 则设置 `ExpireTime = CreatedAt + Timeout`
+  - _需求：3.1、3.2、3.3_
+
+  - [ ]* 2.1 为 TTL 过期行为编写属性测试
+    - **属性 6：TTL 过期行为**
+    - **验证：需求 3.1、3.2、3.3**
+    - 在 `pkg/storage/memory/memory_test.go` 中，测试过期前可查询、过期后返回 `NoDataError`、无 TTL 永不过期
+
+  - [ ]* 2.2 为插入时间戳正确性编写属性测试
+    - **属性 3：插入时间戳正确性**
+    - **验证：需求 1.3**
+    - 在 `pkg/storage/memory/memory_test.go` 中，断言 `createdAt`/`updatedAt` 在操作前后时间范围内
+
+- [x] 3. 实现数据更新接口
+  - 修改 `pkg/storage/memory/memory.go` 的 `Update`：将 `data []byte` 改为 `data interface{}`，更新 `updatedAt` 时间戳，若未传入新 TTL 则保留原 `expireTime`
+  - 同步修改 `pkg/apis/v1/storage/types.go` 中 `Storage` 接口的 `Update` 签名
+  - 在 `pkg/services/rest/data.go` 的 `DataHandler` 中新增 `update` 方法，注册 `POST /v1/data/:prefix` 路由
+  - _需求：5.1、5.2、5.3_
+
+  - [ ]* 3.1 为更新后数据一致性编写属性测试
+    - **属性 8：更新后数据一致性**
+    - **验证：需求 5.1**
+    - 在 `pkg/storage/memory/memory_test.go` 中，插入后更新，断言查询返回新值且 `updatedAt` 更晚
+
+  - [ ]* 3.2 为更新保留原有 TTL 编写属性测试
+    - **属性 7：更新保留原有 TTL**
+    - **验证：需求 3.4、5.3**
+    - 在 `pkg/storage/memory/memory_test.go` 中，带 TTL 插入后不传新 TTL 更新，断言 `expireTime` 不变
+
+- [x] 4. 完善存储层基础读写行为
+  - 修复 `pkg/storage/memory/memory.go` 的 `Insert`：检测到 `PrefixExisted` 时不写入 `prefixList`
+  - 确认 `Delete` 在 Prefix 不存在时返回 `PrefixNotExisted`（已有，确认无误）
+  - _需求：1.1、1.2、6.2_
+
+  - [ ]* 4.1 为插入-查询往返一致性编写属性测试
+    - **属性 1：插入-查询往返一致性**
+    - **验证：需求 1.1、1.4、4.1**
+    - 在 `pkg/storage/memory/memory_test.go` 中，随机 Prefix + 随机数据，插入后查询断言数据相同
+
+  - [ ]* 4.2 为重复插入拒绝编写属性测试
+    - **属性 2：重复插入拒绝**
+    - **验证：需求 1.2**
+    - 在 `pkg/storage/memory/memory_test.go` 中，同一 Prefix 插入两次，断言第二次返回 `PrefixExisted` 且数据不变
+
+- [x] 5. 检查点 — 确保所有测试通过
+  - 确保所有测试通过，如有疑问请向用户确认。
+
+- [x] 6. 完善 PrefixTree Handler 与 HTTP 错误映射
+  - 在 `pkg/handlers/data.go` 的 `InsertNode` 中：若 Prefix 为空则返回描述性错误；将 `storage.StorageClient.Insert` 的 `PrefixExisted` 错误向上透传
+  - 在 `pkg/handlers/data.go` 的 `RemoveNode` 中：将 `PrefixNotExisted` 错误向上透传
+  - 修改 `pkg/services/rest/data.go`：根据错误类型映射到正确 HTTP 状态码（`PrefixExisted` → 409，`NoDataError`/`PrefixNotExisted` → 404，其他 → 500）
+  - 在 `pkg/services/response/response.go` 中新增 `ResponseConflict`（409）响应函数
+  - _需求：7.2、7.3、7.4_
+
+  - [ ]* 6.1 为 HTTP 接口各端点编写单元测试
+    - 测试 PUT 创建（201）、重复创建（409）、GET 存在（200）、GET 不存在（404）、DELETE（200/404）、POST 更新（200/404）
+    - 在 `pkg/services/rest/data_test.go` 中实现
+
+- [x] 7. 完善 Prefix 解析与往返一致性
+  - 检查 `pkg/apis/v1/prefix-tree/types.go` 的 `SplitPrefix`：确认前导 `/` 去除逻辑正确
+  - 新增 `PrefixGroup.Rejoin() string` 方法，将 PrefixGroup 重新拼接为完整 Prefix 字符串
+  - _需求：2.1、2.2、10.1、10.2、10.3、10.4_
+
+  - [ ]* 7.1 为 Prefix 解析往返一致性编写属性测试
+    - **属性 4：Prefix 解析往返一致性**
+    - **验证：需求 2.5、10.1、10.2、10.3、10.4**
+    - 在 `pkg/apis/v1/prefix-tree/types_test.go` 中，随机多级路径字符串，解析后拼接断言等价
+
+- [x] 8. 完善前缀查询与 PrefixTree 节点操作
+  - 修改 `pkg/handlers/data.go` 的 `ListNode`：当路径前缀下无子节点时返回空列表而非错误
+  - 修改 `pkg/handlers/data.go` 的 `RemoveNode`：删除末端节点后将对应 `PrefixNode.HasData` 置为 `false`，保留节点结构
+  - _需求：4.3、4.4、6.1、6.3_
+
+  - [ ]* 8.1 为前缀查询完整性编写属性测试
+    - **属性 5：前缀查询完整性**
+    - **验证：需求 2.4、4.3**
+    - 在 `pkg/handlers/data_test.go` 中，随机父路径下插入若干子节点，断言查询结果恰好包含所有子节点
+
+  - [ ]* 8.2 为删除后不可查询编写属性测试
+    - **属性 9：删除后不可查询**
+    - **验证：需求 6.1、6.3**
+    - 在 `pkg/handlers/data_test.go` 中，插入后删除，断言查询返回 `NoDataError` 且节点 `HasData` 为 `false`
+
+  - [ ]* 8.3 为空路径前缀查询返回空列表编写属性测试
+    - **属性 11：空路径前缀查询返回空列表**
+    - **验证：需求 4.4**
+    - 在 `pkg/handlers/data_test.go` 中，查询不存在子节点的路径，断言返回空列表
+
+- [x] 9. 实现 Module 嵌入客户端
+  - 新建 `pkg/client/cache.go`，定义 `CacheClient` 接口及其实现，包含 `Insert`、`Get`、`Update`、`Delete`、`ListByPrefix` 方法
+  - 实现复用 `pkg/handlers` 与 `pkg/storage` 的现有逻辑，不启动 HTTP 监听
+  - 支持通过 `item.Option`（如 `WithTTL`）传入配置参数
+  - _需求：8.1、8.2、8.3、8.4_
+
+- [x] 10. 检查点 — 确保所有测试通过
+  - 确保所有测试通过，如有疑问请向用户确认。
+
+- [x] 11. 集成收尾与路由注册验证
+  - 确认 `POST /v1/data/:prefix` 已在 `DataHandler.RegisterRouter` 中注册
+  - 确认 `GET /healthz` 正常响应（已有，确认无误）
+  - 确认所有 `init()` 注册的 Controller 均已正确加载
+  - _需求：7.1、7.5、7.6_
+
+## 备注
+
+- 标有 `*` 的子任务为可选项，可跳过以加快 MVP 交付
+- 每个任务均引用具体需求条款以保证可追溯性
+- 属性测试使用 [gopter](https://github.com/leanovate/gopter) 库，每个属性最少运行 100 次迭代
+- 单元测试与属性测试互补：单元测试覆盖具体示例与边界条件，属性测试验证通用正确性

--- a/pkg/apis/v1/item/types.go
+++ b/pkg/apis/v1/item/types.go
@@ -16,3 +16,11 @@ type Option func(item *Item)
 func (i *Item) String() string {
 	return i.Prefix
 }
+
+// WithTTL returns an Option that sets the Timeout field on an Item.
+// The actual ExpireTime is computed in the storage layer after CreatedAt is set.
+func WithTTL(d time.Duration) Option {
+	return func(i *Item) {
+		i.Timeout = d
+	}
+}

--- a/pkg/apis/v1/prefix-tree/types.go
+++ b/pkg/apis/v1/prefix-tree/types.go
@@ -45,6 +45,17 @@ func (pg *PrefixGroup) IsEmpty() bool {
 	return false
 }
 
+func (pg *PrefixGroup) Rejoin() string {
+	if pg.RootPrefix == "" {
+		return ""
+	}
+	if len(pg.PrefixPath) == 0 {
+		return pg.RootPrefix
+	}
+	parts := append([]string{pg.RootPrefix}, pg.PrefixPath...)
+	return strings.Join(parts, "/")
+}
+
 type PrefixNode struct {
 	Prefix    Prefix        `json:"prefix"`
 	HasData   bool          `json:"hasData"`

--- a/pkg/apis/v1/storage/types.go
+++ b/pkg/apis/v1/storage/types.go
@@ -9,6 +9,6 @@ type Storage interface {
 	ListPrefix(prePrefix string) ([]string, error)
 	CountPrefix(prePrefix string) int
 	Insert(prefix string, data interface{}, opt ...item.Option) error
-	Update(prefix string, data []byte, opt ...item.Option) error
+	Update(prefix string, data interface{}, opt ...item.Option) error
 	Delete(prefix string) (interface{}, error)
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,54 @@
+package cache
+
+import (
+	"github.com/mcache-team/mcache/pkg/apis/v1/item"
+	"github.com/mcache-team/mcache/pkg/handlers"
+	"github.com/mcache-team/mcache/pkg/storage"
+)
+
+// CacheClient is the embedded module interface for direct in-process cache access.
+// It provides the same CRUD and prefix-query operations as the HTTP service,
+// without starting any HTTP listener.
+type CacheClient interface {
+	Insert(prefix string, data interface{}, opts ...item.Option) error
+	Get(prefix string) (*item.Item, error)
+	Update(prefix string, data interface{}, opts ...item.Option) error
+	Delete(prefix string) error
+	ListByPrefix(prefix string) ([]*item.Item, error)
+}
+
+type cacheClient struct{}
+
+// NewCacheClient returns a CacheClient that reuses the shared PrefixHandler
+// and StorageClient, keeping behaviour consistent with the HTTP service.
+func NewCacheClient() CacheClient {
+	return &cacheClient{}
+}
+
+// Insert stores data under prefix in both the PrefixTree and Storage.
+// Any item.Option values (e.g. WithTTL) are forwarded to the storage layer.
+func (c *cacheClient) Insert(prefix string, data interface{}, opts ...item.Option) error {
+	return handlers.PrefixHandler.InsertNode(prefix, data, opts...)
+}
+
+// Get retrieves the item stored at the exact prefix.
+func (c *cacheClient) Get(prefix string) (*item.Item, error) {
+	return storage.StorageClient.GetOne(prefix)
+}
+
+// Update replaces the data at an existing prefix and updates the timestamp.
+// If opts contains a new TTL it will overwrite the existing expireTime;
+// otherwise the original expireTime is preserved.
+func (c *cacheClient) Update(prefix string, data interface{}, opts ...item.Option) error {
+	return storage.StorageClient.Update(prefix, data, opts...)
+}
+
+// Delete removes the item from Storage and marks the PrefixTree node as having no data.
+func (c *cacheClient) Delete(prefix string) error {
+	return handlers.PrefixHandler.RemoveNode(prefix)
+}
+
+// ListByPrefix returns all direct child items under the given prefix path.
+func (c *cacheClient) ListByPrefix(prefix string) ([]*item.Item, error) {
+	return handlers.PrefixHandler.ListNode(prefix)
+}

--- a/pkg/handlers/data.go
+++ b/pkg/handlers/data.go
@@ -25,6 +25,8 @@ func (p *prefixTree) ListNode(prefix string) (list []*item.Item, err error) {
 	}
 	var prefixNode *v1.PrefixNode
 	if prefixNode, err = p.searchNode(prefixGroup); err != nil {
+		list = []*item.Item{}
+		err = nil
 		return
 	}
 	list = make([]*item.Item, 0, len(prefixNode.SubPrefix))
@@ -32,6 +34,10 @@ func (p *prefixTree) ListNode(prefix string) (list []*item.Item, err error) {
 		var data *item.Item
 		data, err = storage.StorageClient.GetOne(prefixItem.Prefix.Before(v1.Prefix(prefix)).String())
 		if err != nil {
+			if errors.Is(err, item.NoDataError) {
+				err = nil
+				continue
+			}
 			return
 		}
 		list = append(list, data)
@@ -75,14 +81,17 @@ func (p *prefixTree) RemoveNode(prefix string) (err error) {
 	return
 }
 
-func (p *prefixTree) InsertNode(prefix string, data interface{}) error {
+func (p *prefixTree) InsertNode(prefix string, data interface{}, opts ...item.Option) error {
+	if prefix == "" {
+		return errors.New("prefix is empty")
+	}
 	prefixGroup := v1.Prefix(prefix).SplitPrefix()
 	node := p.mergeTree(prefixGroup)
 	logrus.Infof("node prefix : %s", prefixGroup.NodePrefix)
 	if node.Prefix == v1.Prefix(prefixGroup.NodePrefix) {
 		node.HasData = true
 	}
-	err := storage.StorageClient.Insert(prefix, data)
+	err := storage.StorageClient.Insert(prefix, data, opts...)
 	return err
 }
 

--- a/pkg/mcache/client.go
+++ b/pkg/mcache/client.go
@@ -1,0 +1,62 @@
+package mcache
+
+import (
+	"github.com/mcache-team/mcache/pkg/apis/v1/item"
+	"github.com/mcache-team/mcache/pkg/handlers"
+	"github.com/mcache-team/mcache/pkg/storage"
+)
+
+// CacheClient defines the interface for interacting with the in-memory cache.
+type CacheClient interface {
+	Insert(prefix string, data interface{}, opts ...item.Option) error
+	Get(prefix string) (*item.Item, error)
+	Update(prefix string, data interface{}, opts ...item.Option) error
+	Delete(prefix string) error
+	ListByPrefix(prefix string) ([]*item.Item, error)
+}
+
+// storageProvider is the subset of storage.storageClient methods we need.
+type storageProvider interface {
+	GetOne(prefix string) (*item.Item, error)
+	Update(prefix string, data interface{}, opt ...item.Option) error
+}
+
+// prefixProvider is the subset of handlers.prefixTree methods we need.
+type prefixProvider interface {
+	InsertNode(prefix string, data interface{}, opts ...item.Option) error
+	RemoveNode(prefix string) error
+	ListNode(prefix string) ([]*item.Item, error)
+}
+
+type cacheClient struct {
+	stor       storageProvider
+	prefixTree prefixProvider
+}
+
+// New returns a CacheClient backed by the global StorageClient and PrefixHandler.
+func New() CacheClient {
+	return &cacheClient{
+		stor:       storage.StorageClient,
+		prefixTree: handlers.PrefixHandler,
+	}
+}
+
+func (c *cacheClient) Insert(prefix string, data interface{}, opts ...item.Option) error {
+	return c.prefixTree.InsertNode(prefix, data, opts...)
+}
+
+func (c *cacheClient) Get(prefix string) (*item.Item, error) {
+	return c.stor.GetOne(prefix)
+}
+
+func (c *cacheClient) Update(prefix string, data interface{}, opts ...item.Option) error {
+	return c.stor.Update(prefix, data, opts...)
+}
+
+func (c *cacheClient) Delete(prefix string) error {
+	return c.prefixTree.RemoveNode(prefix)
+}
+
+func (c *cacheClient) ListByPrefix(prefix string) ([]*item.Item, error) {
+	return c.prefixTree.ListNode(prefix)
+}

--- a/pkg/services/rest/data.go
+++ b/pkg/services/rest/data.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"errors"
 	"github.com/gin-gonic/gin"
 	"github.com/mcache-team/mcache/pkg/apis/v1/item"
 	"github.com/mcache-team/mcache/pkg/handlers"
@@ -29,6 +30,7 @@ func (d *DataHandler) RegisterRouter(e *gin.Engine) {
 	group.GET("/:prefix", d.get)
 	group.DELETE("/:prefix", d.delete)
 	group.PUT("", d.create)
+	group.POST("/:prefix", d.update)
 }
 
 func (d *DataHandler) get(ctx *gin.Context) {
@@ -49,6 +51,10 @@ func (d *DataHandler) create(ctx *gin.Context) {
 		return
 	}
 	if err := handlers.PrefixHandler.InsertNode(req.Prefix, req.Data); err != nil {
+		if errors.Is(err, item.PrefixExisted) {
+			response.ResponseAlreadyExists(ctx)
+			return
+		}
 		response.ResponseInternalServerError(ctx, err)
 		return
 	}
@@ -58,10 +64,32 @@ func (d *DataHandler) create(ctx *gin.Context) {
 func (d *DataHandler) delete(ctx *gin.Context) {
 	prefix := ctx.Param("prefix")
 	if err := handlers.PrefixHandler.RemoveNode(prefix); err != nil {
+		if errors.Is(err, item.PrefixNotExisted) || errors.Is(err, item.NoDataError) {
+			response.ResponseNotFound(ctx)
+			return
+		}
 		response.ResponseInternalServerError(ctx, err)
 	} else {
 		response.ResponseSuccess(ctx)
 	}
+}
+
+func (d *DataHandler) update(ctx *gin.Context) {
+	prefix := ctx.Param("prefix")
+	var req item.Item
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		response.ResponseBadRequest(ctx, err)
+		return
+	}
+	var opts []item.Option
+	if req.Timeout > 0 {
+		opts = append(opts, item.WithTTL(req.Timeout))
+	}
+	if err := storage.StorageClient.Update(prefix, req.Data, opts...); err != nil {
+		response.RespondFailure(ctx, err)
+		return
+	}
+	response.ResponseSuccess(ctx)
 }
 
 func (d *DataHandler) listByPrefix(ctx *gin.Context) {

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Memory struct {
+	mu         sync.RWMutex
 	prefixList []string
 	dataMap    *sync.Map
 }
@@ -25,11 +26,16 @@ func NewStorage() storage.Storage {
 	}
 }
 func (m *Memory) GetOne(prefix string) (*item.Item, error) {
-	if data, has := m.dataMap.Load(prefix); has {
-		item := data.(*item.Item)
-		return item, nil
+	data, has := m.dataMap.Load(prefix)
+	if !has {
+		return nil, item.NoDataError
 	}
-	return nil, item.NoDataError
+	it := data.(*item.Item)
+	if !it.ExpireTime.IsZero() && it.ExpireTime.Before(time.Now()) {
+		m.Delete(prefix)
+		return nil, item.NoDataError
+	}
+	return it, nil
 }
 
 // ListPrefixData
@@ -65,6 +71,8 @@ func (m *Memory) CountPrefixData(prefixList []string) int {
 }
 
 func (m *Memory) ListPrefix(prePrefix string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	result := make([]string, 0)
 	for _, item := range m.prefixList {
 		if strings.HasPrefix(item, prePrefix) {
@@ -75,6 +83,8 @@ func (m *Memory) ListPrefix(prePrefix string) ([]string, error) {
 }
 
 func (m *Memory) CountPrefix(prePrefix string) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	count := 0
 	for _, item := range m.prefixList {
 		if strings.HasPrefix(item, prePrefix) {
@@ -85,32 +95,44 @@ func (m *Memory) CountPrefix(prePrefix string) int {
 }
 
 func (m *Memory) Insert(prefix string, data interface{}, opt ...item.Option) error {
-	if _, has := m.dataMap.Load(prefix); has {
-		return item.PrefixExisted
-	}
+	now := time.Now()
 	cacheItem := &item.Item{
 		Prefix:    prefix,
 		Data:      data,
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		CreatedAt: now,
+		UpdatedAt: now,
 	}
 	for _, op := range opt {
 		op(cacheItem)
 	}
-	m.dataMap.Store(prefix, cacheItem)
+	if cacheItem.Timeout > 0 {
+		cacheItem.ExpireTime = cacheItem.CreatedAt.Add(cacheItem.Timeout)
+	}
+	if _, loaded := m.dataMap.LoadOrStore(prefix, cacheItem); loaded {
+		return item.PrefixExisted
+	}
+	m.mu.Lock()
 	m.prefixList = append(m.prefixList, prefix)
+	m.mu.Unlock()
 	return nil
 }
 
-func (m *Memory) Update(prefix string, data []byte, opt ...item.Option) error {
+func (m *Memory) Update(prefix string, data interface{}, opt ...item.Option) error {
 	existed, has := m.dataMap.Load(prefix)
 	if !has {
 		return item.NoDataError
 	}
 	cacheItem := existed.(*item.Item)
 	cacheItem.Data = data
+	cacheItem.UpdatedAt = time.Now()
+	oldExpireTime := cacheItem.ExpireTime
 	for _, op := range opt {
 		op(cacheItem)
+	}
+	if cacheItem.Timeout > 0 {
+		cacheItem.ExpireTime = time.Now().Add(cacheItem.Timeout)
+	} else {
+		cacheItem.ExpireTime = oldExpireTime
 	}
 	m.dataMap.Store(prefix, cacheItem)
 	return nil
@@ -123,10 +145,13 @@ func (m *Memory) Delete(prefix string) (interface{}, error) {
 		return nil, item.PrefixNotExisted
 	}
 	m.dataMap.Delete(prefix)
+	m.mu.Lock()
 	for idx, item := range m.prefixList {
 		if item == prefix {
 			m.prefixList = append(m.prefixList[:idx], m.prefixList[idx+1:]...)
+			break
 		}
 	}
+	m.mu.Unlock()
 	return data.(*item.Item).Data, nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -37,7 +37,7 @@ func (s *storageClient) Insert(prefix string, data interface{}, opt ...item.Opti
 	return s.store.Insert(prefix, data, opt...)
 }
 
-func (s *storageClient) Update(prefix string, data []byte, opt ...item.Option) error {
+func (s *storageClient) Update(prefix string, data interface{}, opt ...item.Option) error {
 	return s.store.Update(prefix, data, opt...)
 }
 


### PR DESCRIPTION
- Add cache service specification documents (.kiro/specs/cache-service)
- Implement cache module with sync.Map-based storage (pkg/cache/cache.go)
- Add memory cache client interface (pkg/mcache/client.go)
- Extend Item type with timeout and expireTime fields for TTL support
- Extend Storage interface with Update method supporting Options
- Extend PrefixTree interface with complete CRUD operations
- Update data handler to support cache operations
- Update memory storage implementation with TTL expiration checks
- Add REST service layer for cache data operations
- Support multi-level key paths with prefix-based hierarchical storage